### PR TITLE
rework: Split home manager config into modules

### DIFF
--- a/modules/programs/direnv.nix
+++ b/modules/programs/direnv.nix
@@ -1,0 +1,5 @@
+{pkgs, ...}: {
+  # Direnv, load and unload environment variables depending on the current directory.
+  programs.direnv.enable = true;
+  programs.direnv.nix-direnv.enable = true;
+}

--- a/modules/programs/git.nix
+++ b/modules/programs/git.nix
@@ -1,0 +1,10 @@
+{pkgs, ...}: {
+  # Setup git
+  programs.git = {
+    enable = true;
+    userName = "nixos";
+    userEmail = "cchuqiming@gmail.com";
+  };
+  # Enable lazygit
+  programs.lazygit.enable = true;
+}

--- a/modules/programs/git.nix
+++ b/modules/programs/git.nix
@@ -2,7 +2,7 @@
   # Setup git
   programs.git = {
     enable = true;
-    userName = "nixos";
+    userName = "Qiming Chu";
     userEmail = "cchuqiming@gmail.com";
   };
   # Enable lazygit

--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -1,0 +1,35 @@
+{pkgs, ...}: {
+  # Enable starship
+  programs.starship = {
+    enable = true;
+    settings = {
+      add_newline = false;
+      aws.disabled = true;
+      gcloud.disabled = true;
+      line_break.disabled = true;
+    };
+  };
+
+  programs.fzf.enable = true;
+  programs.zoxide.enable = true;
+
+  programs.zsh = {
+    enable = true;
+    enableCompletion = true;
+    initExtra = ''
+      export PATH="$PATH:$HOME/bin:$HOME/.local/bin"
+    '';
+
+    # Set aliases
+    shellAliases = {
+      lg = "lazygit";
+      gv = "git remote -v";
+    };
+    syntaxHighlighting.enable = true;
+    history = {
+      ignoreDups = true;
+      save = 1000000;
+      size = 1000000;
+    };
+  };
+}

--- a/system/darwin/home.nix
+++ b/system/darwin/home.nix
@@ -8,10 +8,6 @@
   home.username = "qimingchu";
   home.homeDirectory = "/Users/qimingchu";
 
-  # Direnv, load and unload environment variables depending on the current directory.
-  programs.direnv.enable = true;
-  programs.direnv.nix-direnv.enable = true;
-
   home.packages = with pkgs;
     [
       curl
@@ -42,14 +38,11 @@
       cocoapods
       m-cli # useful macOS CLI commands
     ];
-  # Setup git
-  programs.git = {
-    enable = true;
-    userName = "Qiming Chu";
-    userEmail = "cchuqiming@gmail.com";
-  };
-  # Enable lazygit
-  programs.lazygit.enable = true;
+
+  imports = [
+    ../../modules/programs/git.nix
+    ../../modules/programs/direnv.nix
+  ];
 
   # This value determines the Home Manager release that your
   # configuration is compatible with. This helps avoid breakage

--- a/system/linux/wsl/home.nix
+++ b/system/linux/wsl/home.nix
@@ -58,49 +58,11 @@
     lsof # list open files
   ];
 
-  # Setup git
-  programs.git = {
-    enable = true;
-    userName = "Emin017";
-    userEmail = "cchuqiming@gmail.com";
-  };
-  # Enable lazygit
-  programs.lazygit.enable = true;
-
-  # Enable starship
-  programs.starship = {
-    enable = true;
-    settings = {
-      add_newline = false;
-      aws.disabled = true;
-      gcloud.disabled = true;
-      line_break.disabled = true;
-    };
-  };
-
-  programs.fzf.enable = true;
-  programs.zoxide.enable = true;
-
-  programs.zsh = {
-    enable = true;
-    enableCompletion = true;
-    initExtra = ''
-      export PATH="$PATH:$HOME/bin:$HOME/.local/bin"
-    '';
-
-    # Set aliases
-    shellAliases = {
-      lg = "lazygit";
-      gv = "git remote -v";
-    };
-    syntaxHighlighting.enable = true;
-    history = {
-      ignoreDups = true;
-      save = 1000000;
-      size = 1000000;
-    };
-  };
-
+  imports = [
+    ../../../modules/programs/zsh.nix
+    ../../../modules/programs/git.nix
+    ../../../modules/programs/direnv.nix
+  ];
   # This value determines the Home Manager release that your
   # configuration is compatible with. This helps avoid breakage
   # when a new Home Manager release introduces backwards


### PR DESCRIPTION
Since I don't want to use the home manager on all systems to manage the software configuration, I have imported different modules on different systems.
@Yakkhini Do you think there is a better solution?