### PR TITLE
refactor(fringe): refine hm modules, remove nix ci cache, add pkgs in hm

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,6 @@ jobs:
           nix_path: nixpkgs=channel:${{ env.NIXPKGS_BRANCH }}
           extra_nix_config: |
             experimental-features = nix-command flakes pipe-operators
-      - uses: DeterminateSystems/magic-nix-cache-action@main
       - name: Install channels
         run: |
           sudo nix-channel --add https://nixos.org/channels/${{ env.NIXPKGS_BRANCH }} nixpkgs
@@ -87,7 +86,6 @@ jobs:
         with:
           extra_nix_config: |
             experimental-features = nix-command flakes pipe-operators
-      - uses: DeterminateSystems/magic-nix-cache-action@main
       - name: Build home-manager configuration
         run: |
           nix build .#homeConfigurations.server.activationPackage

--- a/system/hosts/fringe/config.nix
+++ b/system/hosts/fringe/config.nix
@@ -10,15 +10,16 @@
 {
   imports =
     let
+      modulePrefix = ./../../modules;
       modules =
         with builtins;
         with lib;
-        ./../../modules
+        modulePrefix
         |> readDir
         |> filterAttrs (name: type: type == "regular")
         |> attrNames
         |> filter (f: f != "minimal.nix") # This file will import zsh.nix and i18n.nix, which are duplicated
-        |> map (f: ./../../modules + "/${f}");
+        |> map (f: modulePrefix + "/${f}");
     in
     modules
     ++ [

--- a/system/hosts/fringe/home.nix
+++ b/system/hosts/fringe/home.nix
@@ -95,13 +95,14 @@
 
   imports =
     let
+      modulePrefix = ../../../modules/programs;
       modules =
         with builtins;
-        ../../../modules/programs
+        modulePrefix
         |> readDir
         |> attrNames
         |> lib.filter (f: f != "yazi.nix" && f != "restic.nix")
-        |> map (f: ../../../modules/programs + "/${f}");
+        |> map (f: modulePrefix + "/${f}");
     in
     modules
     ++ [

--- a/system/hosts/fringe/home.nix
+++ b/system/hosts/fringe/home.nix
@@ -35,6 +35,8 @@
     fzf # A command-line fuzzy finder
     icdiff
 
+    lazygit # A simple terminal UI for git
+
     # networking tools
     mtr # A network diagnostic tool
     iperf3
@@ -95,9 +97,17 @@
     let
       modules =
         with builtins;
-        ../../../modules/programs |> readDir |> attrNames |> map (f: ../../../modules/programs + "/${f}");
+        ../../../modules/programs
+        |> readDir
+        |> attrNames
+        |> lib.filter (f: f != "yazi.nix" && f != "restic.nix")
+        |> map (f: ../../../modules/programs + "/${f}");
     in
-    modules ++ [ inputs.zen-browser.homeModules.beta ];
+    modules
+    ++ [
+      ../../../modules/neovim
+      inputs.zen-browser.homeModules.beta
+    ];
   programs.zen-browser.enable = true;
   programs.zen-browser.policies = {
     DisableAppUpdate = true;

--- a/system/modules/user.nix
+++ b/system/modules/user.nix
@@ -13,6 +13,7 @@
     packages = with pkgs; [
       #  thunderbird
       # firefox
+      neovim
     ];
   };
 


### PR DESCRIPTION
This pull request makes several improvements to the NixOS configuration, focusing on simplifying module imports, updating the package list, and cleaning up the GitHub Actions workflow. The most significant changes include refactoring how modules are imported in the host and home configuration files, updating the list of installed packages, and removing a caching action from the CI workflow.

**Configuration and Module Import Improvements:**

* Refactored module imports in `system/hosts/fringe/config.nix` and `system/hosts/fringe/home.nix` to use a `modulePrefix` variable, improving readability and maintainability. Also added filtering to exclude certain modules (`minimal.nix`, `yazi.nix`, and `restic.nix`) from imports and included the `neovim` module explicitly. [[1]](diffhunk://#diff-63f02340d0cf2b9ce4bd6317678c97b6bbb7ae78639654d55de943651a128c85R13-R22) [[2]](diffhunk://#diff-564d3537801427c2869ae35fa5d4eccddda86e2ed0e57eb53bc5b21a1960eee3R98-R111)

**Package List Updates:**

* Added `lazygit` and `neovim` to the list of installed packages in `system/hosts/fringe/home.nix` and `system/modules/user.nix`, enhancing the development environment with additional tools. [[1]](diffhunk://#diff-564d3537801427c2869ae35fa5d4eccddda86e2ed0e57eb53bc5b21a1960eee3R38-R39) [[2]](diffhunk://#diff-97f41af1bfad141a5cefcb18b5aeb43d0d2b8e51918a27ada572510505eb674cR16)

**CI Workflow Cleanup:**

* Removed the `DeterminateSystems/magic-nix-cache-action` from the `.github/workflows/test.yml` file, simplifying the workflow and potentially addressing caching or reliability issues. [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L47) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L90)